### PR TITLE
fix(shader-mode.el): Autoload mode-alist

### DIFF
--- a/shader-mode.el
+++ b/shader-mode.el
@@ -188,6 +188,7 @@
   (set (make-local-variable 'electric-indent-chars)
        (append "{}()[]" electric-indent-chars)))
 
+;;;###autoload
 (add-to-list 'auto-mode-alist '("\\.shader$" . shader-mode))
 
 (provide 'shader-mode)


### PR DESCRIPTION
Let's autoload the `auto-mode-list` so users don't have to do `(require 'shader-mode)`.